### PR TITLE
Add support for all AVR MCUs

### DIFF
--- a/src/SevenSegmentTM1637.h
+++ b/src/SevenSegmentTM1637.h
@@ -413,8 +413,8 @@ protected:
     #define TM1637_DEBUG_MESSAGELN(x)
 #endif
 
-// direct port access macros for more speed ( communication is ~us)
-#ifdef __AVR
+// arduino:standard variant direct port access macros for more speed ( communication is ~us)
+#if defined(__AVR_ATmega8__) || defined(__AVR_ATmega8A__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega168A__) || defined(__AVR_ATmega168P__) || defined(__AVR_ATmega168PA__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
   #define portOfPin(P) \
     ( ((P) >= 0 && (P) < 8)? &PORTD:( ((P) > 7 && (P) < 14) ? &PORTB: &PORTC ) )
   #define ddrOfPin(P) \


### PR DESCRIPTION
Previously, the code only supported the arduino:standard variant and non-AVRs. This change causes the standard Arduino digital I/O functions to be used for all other AVRs.

I have reconsidered my previous pull request and removed the direct port access macros for ATmega32u4. The reason is that although they are significantly faster than the Arduino functions, they also significantly increase the program size, even after some refactoring to make them smaller and faster.

Using Arduino IDE 1.6.9 with Pro Micro:

type | digitalLow/High average(us) | Basic.ino program storage space(bytes)
----|----|----
Direct port access macros | 2.68 | 13046
Arduino functions | 6.40 | 7548