### PR TITLE
esp8266 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 libraries
 sketches
+/.project

--- a/src/SevenSegmentTM1637.h
+++ b/src/SevenSegmentTM1637.h
@@ -20,12 +20,10 @@
  #include <WProgram.h>
 #endif
 
-//#include <avr/pgmspace.h>   // Used for PROGMEM
-// esp8266 compatibility
 #if (defined(__AVR__))
-#include <avr\pgmspace.h>
+#include <avr/pgmspace.h> // Used for PROGMEM (arduino)
 #else
-#include <pgmspace.h>
+#include <pgmspace.h> // Used for PROGMEM (esp8266)
 #endif
 
 // COMPILE TIME USER CONFIG ////////////////////////////////////////////////////

--- a/src/SevenSegmentTM1637.h
+++ b/src/SevenSegmentTM1637.h
@@ -20,7 +20,13 @@
  #include <WProgram.h>
 #endif
 
-#include <avr/pgmspace.h>   // Used for PROGMEM
+//#include <avr/pgmspace.h>   // Used for PROGMEM
+// esp8266 compatibility
+#if (defined(__AVR__))
+#include <avr\pgmspace.h>
+#else
+#include <pgmspace.h>
+#endif
 
 // COMPILE TIME USER CONFIG ////////////////////////////////////////////////////
 #define TM1637_DEBUG                  false   // true for serial debugging


### PR DESCRIPTION
The pgmspace.h for esp8266 board (https://github.com/esp8266/Arduino) is on a different path. This change make your code compatible with these boards.