### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,40 +6,40 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SevenSegmentTM1637    KEYWORD1
-SevenSegmentExtended  KEYWORD1
-SevenSegmentFun       KEYWORD1
+SevenSegmentTM1637	KEYWORD1
+SevenSegmentExtended	KEYWORD1
+SevenSegmentFun	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-write             KEYWORD2
-init              KEYWORD2
-begin             KEYWORD2
-clear             KEYWORD2
-home              KEYWORD2
-on                KEYWORD2
-off               KEYWORD2
-printRaw          KEYWORD2
-printTime         KEYWORD2
-printDualCounter  KEYWORD2
-blink             KEYWORD2
-setBacklight      KEYWORD2
-setContrast       KEYWORD2
-setCursor         KEYWORD2
-setColonOn        KEYWORD2
-getColonOn        KEYWORD2
-setPrintDelay     KEYWORD2
-encode            KEYWORD2
-encode            KEYWORD2
-shiftLeft         KEYWORD2
-command           KEYWORD2
-comReadByte       KEYWORD2
-comWriteByte      KEYWORD2
-comStart          KEYWORD2
-comStop           KEYWORD2
-comAck            KEYWORD2
+write	KEYWORD2
+init	KEYWORD2
+begin	KEYWORD2
+clear	KEYWORD2
+home	KEYWORD2
+on	KEYWORD2
+off	KEYWORD2
+printRaw	KEYWORD2
+printTime	KEYWORD2
+printDualCounter	KEYWORD2
+blink	KEYWORD2
+setBacklight	KEYWORD2
+setContrast	KEYWORD2
+setCursor	KEYWORD2
+setColonOn	KEYWORD2
+getColonOn	KEYWORD2
+setPrintDelay	KEYWORD2
+encode	KEYWORD2
+encode	KEYWORD2
+shiftLeft	KEYWORD2
+command	KEYWORD2
+comReadByte	KEYWORD2
+comWriteByte	KEYWORD2
+comStart	KEYWORD2
+comStop	KEYWORD2
+comAck	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords