### PR TITLE
Update SevenSegmentTM1637.cpp

### DIFF
--- a/src/SevenSegmentTM1637.cpp
+++ b/src/SevenSegmentTM1637.cpp
@@ -54,14 +54,14 @@ size_t  SevenSegmentTM1637::write(uint8_t byte) {
 // null terminated char array
 size_t  SevenSegmentTM1637::write(const char* str) {
   TM1637_DEBUG_PRINT(F("write char*:\t")); TM1637_DEBUG_PRINTLN(str);
-  uint8_t encodedBytes[4];
+  uint8_t encodedBytes[TM1637_MAX_COLOM];
 
-  encode(encodedBytes, str, 4);
-  uint8_t i =4;
+  encode(encodedBytes, str, TM1637_MAX_COLOM);
+  uint8_t i = TM1637_MAX_COLOM;
   while( str[i] != '\0' ) {
     printRaw(encodedBytes);
-    shiftLeft(encodedBytes, 4);
-    encodedBytes[3] = encode( str[i] );
+    shiftLeft(encodedBytes, TM1637_MAX_COLOM);
+    encodedBytes[TM1637_MAX_COLOM-1] = encode( str[i] );
     i++;
     if ( i == TM1637_MAX_CHARS) {
       break;
@@ -102,7 +102,7 @@ void SevenSegmentTM1637::init(uint8_t cols, uint8_t rows) {
 }
 
 void SevenSegmentTM1637::clear(void) {
-  uint8_t rawBytes[4] = {0,0,0,0};
+  uint8_t rawBytes[TM1637_MAX_COLOM] = {0,0,0,0};
   printRaw(rawBytes);
   home();
 };
@@ -228,13 +228,13 @@ void  SevenSegmentTM1637::printRaw(const uint8_t* rawBytes, size_t length, uint8
   }
   // does not fit on display, need to print with delay
   else {
-    // First print 1-4 characters
+    // First print 1-(TM1637_MAX_COLOM-1) characters
     uint8_t numtoPrint = _numCols - position;
     printRaw(rawBytes, numtoPrint, position);
     delay(_printDelay);
 
     // keep printing 4 characters till done
-    uint8_t remaining = length - numtoPrint + 3;
+    uint8_t remaining = length - numtoPrint + TM1637_MAX_COLOM - 1;
     uint8_t i         = 1;
     while( remaining >= _numCols) {
       printRaw(&rawBytes[i], _numCols, 0);

--- a/src/SevenSegmentTM1637.cpp
+++ b/src/SevenSegmentTM1637.cpp
@@ -124,7 +124,7 @@ void SevenSegmentTM1637::setBacklight(uint8_t value) {
   // scale backlight value to 0..8
   value /= 10;                          // 0..10
   value = (value > 8   )?  8:value;     // only 8 levels and off
-  uint8_t cmd = TM1637_COM_SET_DISPLAY;;
+  uint8_t cmd = TM1637_COM_SET_DISPLAY;
   switch ( value ) {
     case 0:
       cmd |= TM1637_SET_DISPLAY_OFF;


### PR DESCRIPTION
Replace all hard coded '4' representing display buffer size to previously declared constant TM1637_MAX_COLOM and replace all hard coded '3' with (TM1637_MAX_COLOM-1). No other changes, maintenance update in preparation for increasing buffer size to 6 for some displays.