### PR TITLE
Make setting the colon on optional for printDualCounter

### DIFF
--- a/src/SevenSegmentExtended.cpp
+++ b/src/SevenSegmentExtended.cpp
@@ -97,7 +97,7 @@ void SevenSegmentExtended::printNumber(int16_t number, bool zeroPadding, bool ro
 };
 
 // positive counter 0..99, negative counter 0..-9
-void SevenSegmentExtended::printDualCounter(int8_t leftCounter, int8_t rightCounter, bool zeroPadding) {
+void SevenSegmentExtended::printDualCounter(int8_t leftCounter, int8_t rightCounter, bool zeroPadding, bool setColonOn) {
 
   int8_t max = 99;
   int8_t min = -9;
@@ -109,7 +109,8 @@ void SevenSegmentExtended::printDualCounter(int8_t leftCounter, int8_t rightCoun
   rightCounter = (rightCounter < min)?min:rightCounter;
 
   bool colonWasOn = getColonOn();     // get current state
-  setColonOn(true);                   // turn on the colon
+  if (setColonOn)
+    SevenSegmentTM1637::setColonOn(true); // turn on the colon
   home();                             // set cursor to zero
 
   if ( leftCounter < 10 && leftCounter >= 0) {
@@ -136,5 +137,5 @@ void SevenSegmentExtended::printDualCounter(int8_t leftCounter, int8_t rightCoun
   print(rightCounter);
 
   // set to previous state
-  setColonOn(colonWasOn);
+  SevenSegmentTM1637::setColonOn(colonWasOn);
 };

--- a/src/SevenSegmentExtended.h
+++ b/src/SevenSegmentExtended.h
@@ -37,8 +37,9 @@ void    printNumber(int16_t number, bool zeroPadding = false, bool rollOver = fa
 @param [in] leftCounter   the number on the left side of the display
 @param [in] rightcounter  the numnber on the right side of the display
 @param [in] zeroPadding   optional: pad counters with zero
+@param [in] setColonOn    optional: set to false to leave colon alone
 */
-void    printDualCounter(int8_t leftCounter, int8_t rightCounter, bool zeroPadding = false);
+void    printDualCounter(int8_t leftCounter, int8_t rightCounter, bool zeroPadding = false, bool setColonOn = true);
 
 };
 #endif


### PR DESCRIPTION
Hello Bram,

This addition makes it so that turning the colon on becomes optional for printDualCounter.  It adds a new parameter setColonOn with a default value of true. If set to true, the method turns the colon on as before; if set to false, it leaves the colon alone. I needed this for a project where I want to blink the colon to show that the loop that is showing numbers is still alive. 

I think old LED alarm clocks used to do this too.

Groetjes - Michiel