### PR TITLE
Bump version to 1.1.2 in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SevenSegmentTM1637
-version=1.1.0
+version=1.1.2
 author=Bram Harmsen <bramharmsen@gmail.com>
 maintainer=Bram Harmsen <bramharmsen@gmail.com>
 sentence=Library for using a 4 digit seven segment display with TM1636 or TM1637 driver IC

--- a/src/SevenSegmentFun.cpp
+++ b/src/SevenSegmentFun.cpp
@@ -24,9 +24,9 @@ void  SevenSegmentFun::printLevelVertical(uint8_t level, bool leftToRight) {
   uint8_t d = leftToRight == true?0:TM1637_MAX_COLOM-1;
 
   for (uint8_t i=0; i < TM1637_MAX_COLOM; i++) {
-    if (barsOn - (2 * (i + 1)) >= 0) {
+    if (barsOn - (2 * i) >= 2) {
       _rawBuffer[d] = TM1637_CHAR_VERT_LEVEL_II;
-    } else if (barsOn - (2 * (i + 1)) >= 1) {
+    } else if (barsOn - (2 * i) >= 1) {
       _rawBuffer[d] = (leftToRight == true)?TM1637_CHAR_VERT_LEVEL_I0:TM1637_CHAR_VERT_LEVEL_0I;
     } else {
       _rawBuffer[d] = 0;


### PR DESCRIPTION
Reflect version change in library.properties so PlatformIO's crawler will update this library.

PlatformIO still has version 1.1.0 simply because library.properties still reads that the current version is 1.1.0 instead of 1.1.1. Updating this will allow people to install the current release through PlatformIO again. 

(Bumped version number to 1.1.2 not 1.1.1 because this change will also require a new release to accompany it, assuming I'm correct that PlatformIO's crawler only looks at releases). 

Closes #50 
Proper fix vs #52 