### PR TITLE
Simplify and correct bar logic

### DIFF
--- a/src/SevenSegmentFun.cpp
+++ b/src/SevenSegmentFun.cpp
@@ -24,9 +24,9 @@ void  SevenSegmentFun::printLevelVertical(uint8_t level, bool leftToRight) {
   uint8_t d = leftToRight == true?0:TM1637_MAX_COLOM-1;
 
   for (uint8_t i=0; i < TM1637_MAX_COLOM; i++) {
-    if (barsOn - (2 * (i + 1)) >= 0) {
+    if (barsOn - (2 * i) >= 2) {
       _rawBuffer[d] = TM1637_CHAR_VERT_LEVEL_II;
-    } else if (barsOn - (2 * (i + 1)) >= 1) {
+    } else if (barsOn - (2 * i) >= 1) {
       _rawBuffer[d] = (leftToRight == true)?TM1637_CHAR_VERT_LEVEL_I0:TM1637_CHAR_VERT_LEVEL_0I;
     } else {
       _rawBuffer[d] = 0;


### PR DESCRIPTION
Logic is intended to check how many bars to draw by examining 2 bar positions at a time.

Previous version the second conditional was always false (because if barsOn-2*i+1 is not >=0 in the first conditional it certainly won't be >=1 in the second. Instead of >=1, the second conditional needed to be >=-1 in the prior logic.

Simplifying the logic so that the value being checked in the conditional corresponds directly to the number of bars to light solves the problem and makes the flow much more directly understandable.