### PR TITLE
Clear the colon when clearing the display

### DIFF
--- a/src/SevenSegmentTM1637.cpp
+++ b/src/SevenSegmentTM1637.cpp
@@ -107,6 +107,7 @@ void SevenSegmentTM1637::init(uint8_t cols, uint8_t rows) {
 }
 
 void SevenSegmentTM1637::clear(void) {
+  setColonOn(false);
   uint8_t rawBytes[4] = {0,0,0,0};
   printRaw(rawBytes);
   home();


### PR DESCRIPTION
Hi, I've been testing out your library and I found that if I enable the colon, then clear the display, the colon persists.

For instance, this sketch will result in the colon staying lit:

```cpp
#include <SevenSegmentTM1637.h>

void setup()
{
    auto display = SevenSegmentTM1637{7, MISO};

    display.setColonOn(true);
    display.print(1234);

    delay(1000);

    display.clear();
}

void loop() {}
```

I think the intended behaviour here is to clear everything when `clear()` is called, which is what I've suggested in this patch.